### PR TITLE
Add localized FAQ strings and accessibility tweaks

### DIFF
--- a/Apps/MainApp/SharedResources/Localization/de.lproj/Localizable.strings
+++ b/Apps/MainApp/SharedResources/Localization/de.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* German */
 "welcome_title" = "Willkommen bei HealthAI 2030";
 "welcome_message" = "Ihre Gesundheit, Ihre Daten, Ihre Zukunft.";
+"faq_general_header" = "Allgemein";
+"faq_privacy_header" = "Datenschutz & Sicherheit";
+"faq_features_header" = "Funktionen";
+"faq_q1" = "Wie verbinde ich meine Apple Watch?";
+"faq_q2" = "Wie exportiere ich meine Gesundheitsdaten?";
+"faq_q3" = "Wie werden meine Daten geschützt?";
+"faq_q4" = "Wie lösche ich mein Konto?";
+"faq_q5" = "Wie verwende ich die Skriptfunktion?";
+"faq_q6" = "Wie trete ich einer Familiengruppe bei?";
+"faq_title" = "FAQ & Hilfe";

--- a/Apps/MainApp/SharedResources/Localization/en.lproj/Localizable.strings
+++ b/Apps/MainApp/SharedResources/Localization/en.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* English */
 "welcome_title" = "Welcome to HealthAI 2030";
 "welcome_message" = "Your health, your data, your future.";
+"faq_general_header" = "General";
+"faq_privacy_header" = "Privacy & Security";
+"faq_features_header" = "Features";
+"faq_q1" = "How do I connect my Apple Watch?";
+"faq_q2" = "How do I export my health data?";
+"faq_q3" = "How is my data protected?";
+"faq_q4" = "How do I delete my account?";
+"faq_q5" = "How do I use the scripting feature?";
+"faq_q6" = "How do I join a family group?";
+"faq_title" = "FAQ & Help";

--- a/Apps/MainApp/SharedResources/Localization/es.lproj/Localizable.strings
+++ b/Apps/MainApp/SharedResources/Localization/es.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* Spanish */
 "welcome_title" = "Bienvenido a HealthAI 2030";
 "welcome_message" = "Tu salud, tus datos, tu futuro.";
+"faq_general_header" = "General";
+"faq_privacy_header" = "Privacidad y Seguridad";
+"faq_features_header" = "Funciones";
+"faq_q1" = "¿Cómo conecto mi Apple Watch?";
+"faq_q2" = "¿Cómo exporto mis datos de salud?";
+"faq_q3" = "¿Cómo se protege mi información?";
+"faq_q4" = "¿Cómo elimino mi cuenta?";
+"faq_q5" = "¿Cómo uso la función de scripting?";
+"faq_q6" = "¿Cómo me uno a un grupo familiar?";
+"faq_title" = "Preguntas Frecuentes y Ayuda";

--- a/Apps/MainApp/SharedResources/Localization/fr.lproj/Localizable.strings
+++ b/Apps/MainApp/SharedResources/Localization/fr.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* French */
 "welcome_title" = "Bienvenue à HealthAI 2030";
 "welcome_message" = "Votre santé, vos données, votre avenir.";
+"faq_general_header" = "Général";
+"faq_privacy_header" = "Confidentialité et sécurité";
+"faq_features_header" = "Fonctionnalités";
+"faq_q1" = "Comment connecter mon Apple Watch ?";
+"faq_q2" = "Comment exporter mes données de santé ?";
+"faq_q3" = "Comment mes données sont-elles protégées ?";
+"faq_q4" = "Comment supprimer mon compte ?";
+"faq_q5" = "Comment utiliser la fonctionnalité de script ?";
+"faq_q6" = "Comment rejoindre un groupe familial ?";
+"faq_title" = "FAQ et Aide";

--- a/Apps/MainApp/SharedResources/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Apps/MainApp/SharedResources/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* Chinese */
 "welcome_title" = "欢迎使用 HealthAI 2030";
 "welcome_message" = "您的健康，您的数据，您的未来。";
+"faq_general_header" = "常见问题";
+"faq_privacy_header" = "隐私与安全";
+"faq_features_header" = "功能";
+"faq_q1" = "如何连接我的 Apple Watch？";
+"faq_q2" = "如何导出我的健康数据？";
+"faq_q3" = "我的数据如何得到保护？";
+"faq_q4" = "如何删除我的帐户？";
+"faq_q5" = "如何使用脚本功能？";
+"faq_q6" = "如何加入家庭群组？";
+"faq_title" = "常见问题与帮助";

--- a/Apps/MainApp/Views/FAQHelpView.swift
+++ b/Apps/MainApp/Views/FAQHelpView.swift
@@ -4,20 +4,26 @@ import SwiftUI
 struct FAQHelpView: View {
     var body: some View {
         List {
-            Section(header: Text("General")) {
-                Text("How do I connect my Apple Watch?")
-                Text("How do I export my health data?")
+            Section(header: Text("faq_general_header")
+                        .font(.headline)
+                        .accessibilityAddTraits(.isHeader)) {
+                Text("faq_q1")
+                Text("faq_q2")
             }
-            Section(header: Text("Privacy & Security")) {
-                Text("How is my data protected?")
-                Text("How do I delete my account?")
+            Section(header: Text("faq_privacy_header")
+                        .font(.headline)
+                        .accessibilityAddTraits(.isHeader)) {
+                Text("faq_q3")
+                Text("faq_q4")
             }
-            Section(header: Text("Features")) {
-                Text("How do I use the scripting feature?")
-                Text("How do I join a family group?")
+            Section(header: Text("faq_features_header")
+                        .font(.headline)
+                        .accessibilityAddTraits(.isHeader)) {
+                Text("faq_q5")
+                Text("faq_q6")
             }
         }
-        .navigationTitle("FAQ & Help")
+        .navigationTitle(Text("faq_title"))
     }
 }
 

--- a/Frameworks/HealthAI2030Core/Sources/Managers/HealthDataManager.swift
+++ b/Frameworks/HealthAI2030Core/Sources/Managers/HealthDataManager.swift
@@ -1,7 +1,4 @@
 import HealthAI2030Core
-import HealthAI2030Core
-import HealthAI2030Core
-import HealthAI2030Core
 import Foundation
 import HealthKit
 import CoreData

--- a/Frameworks/Shared/Sources/Shared/Localization/de.lproj/Localizable.strings
+++ b/Frameworks/Shared/Sources/Shared/Localization/de.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* German */
 "welcome_title" = "Willkommen bei HealthAI 2030";
 "welcome_message" = "Ihre Gesundheit, Ihre Daten, Ihre Zukunft.";
+"faq_general_header" = "Allgemein";
+"faq_privacy_header" = "Datenschutz & Sicherheit";
+"faq_features_header" = "Funktionen";
+"faq_q1" = "Wie verbinde ich meine Apple Watch?";
+"faq_q2" = "Wie exportiere ich meine Gesundheitsdaten?";
+"faq_q3" = "Wie werden meine Daten geschützt?";
+"faq_q4" = "Wie lösche ich mein Konto?";
+"faq_q5" = "Wie verwende ich die Skriptfunktion?";
+"faq_q6" = "Wie trete ich einer Familiengruppe bei?";
+"faq_title" = "FAQ & Hilfe";

--- a/Frameworks/Shared/Sources/Shared/Localization/en.lproj/Localizable.strings
+++ b/Frameworks/Shared/Sources/Shared/Localization/en.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* English */
 "welcome_title" = "Welcome to HealthAI 2030";
 "welcome_message" = "Your health, your data, your future.";
+"faq_general_header" = "General";
+"faq_privacy_header" = "Privacy & Security";
+"faq_features_header" = "Features";
+"faq_q1" = "How do I connect my Apple Watch?";
+"faq_q2" = "How do I export my health data?";
+"faq_q3" = "How is my data protected?";
+"faq_q4" = "How do I delete my account?";
+"faq_q5" = "How do I use the scripting feature?";
+"faq_q6" = "How do I join a family group?";
+"faq_title" = "FAQ & Help";

--- a/Frameworks/Shared/Sources/Shared/Localization/es.lproj/Localizable.strings
+++ b/Frameworks/Shared/Sources/Shared/Localization/es.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* Spanish */
 "welcome_title" = "Bienvenido a HealthAI 2030";
 "welcome_message" = "Tu salud, tus datos, tu futuro.";
+"faq_general_header" = "General";
+"faq_privacy_header" = "Privacidad y Seguridad";
+"faq_features_header" = "Funciones";
+"faq_q1" = "¿Cómo conecto mi Apple Watch?";
+"faq_q2" = "¿Cómo exporto mis datos de salud?";
+"faq_q3" = "¿Cómo se protege mi información?";
+"faq_q4" = "¿Cómo elimino mi cuenta?";
+"faq_q5" = "¿Cómo uso la función de scripting?";
+"faq_q6" = "¿Cómo me uno a un grupo familiar?";
+"faq_title" = "Preguntas Frecuentes y Ayuda";

--- a/Frameworks/Shared/Sources/Shared/Localization/fr.lproj/Localizable.strings
+++ b/Frameworks/Shared/Sources/Shared/Localization/fr.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* French */
 "welcome_title" = "Bienvenue à HealthAI 2030";
 "welcome_message" = "Votre santé, vos données, votre avenir.";
+"faq_general_header" = "Général";
+"faq_privacy_header" = "Confidentialité et sécurité";
+"faq_features_header" = "Fonctionnalités";
+"faq_q1" = "Comment connecter mon Apple Watch ?";
+"faq_q2" = "Comment exporter mes données de santé ?";
+"faq_q3" = "Comment mes données sont-elles protégées ?";
+"faq_q4" = "Comment supprimer mon compte ?";
+"faq_q5" = "Comment utiliser la fonctionnalité de script ?";
+"faq_q6" = "Comment rejoindre un groupe familial ?";
+"faq_title" = "FAQ et Aide";

--- a/Frameworks/Shared/Sources/Shared/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Frameworks/Shared/Sources/Shared/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,13 @@
 /* Chinese */
 "welcome_title" = "欢迎使用 HealthAI 2030";
 "welcome_message" = "您的健康，您的数据，您的未来。";
+"faq_general_header" = "常见问题";
+"faq_privacy_header" = "隐私与安全";
+"faq_features_header" = "功能";
+"faq_q1" = "如何连接我的 Apple Watch？";
+"faq_q2" = "如何导出我的健康数据？";
+"faq_q3" = "我的数据如何得到保护？";
+"faq_q4" = "如何删除我的帐户？";
+"faq_q5" = "如何使用脚本功能？";
+"faq_q6" = "如何加入家庭群组？";
+"faq_title" = "常见问题与帮助";


### PR DESCRIPTION
## Summary
- remove duplicate imports in `HealthDataManager`
- localize FAQ help view across all languages
- enhance FAQ view accessibility and dynamic text support

## Testing
- `./Scripts/run_all_tests.sh` *(fails: package 'healthai2030analytics' requires tools version 6.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68782a160ce88321b97085a8e8475a93