### PR TITLE
Improve release scripts

### DIFF
--- a/Scripts/Release/validate_release.sh
+++ b/Scripts/Release/validate_release.sh
@@ -1,6 +1,15 @@
 #!/bin/zsh
 # Validate release readiness for HealthAI 2030
-set -e
+set -euo pipefail
+IFS=$'\n\t'
+
+trap 'echo "ERROR: Release validation failed" >&2' ERR
+
+echo "==> Ensuring working tree is clean..."
+if ! git diff-index --quiet HEAD --; then
+  echo "ERROR: Uncommitted changes detected. Commit or stash before releasing."
+  exit 1
+fi
 
 echo "==> Checking test coverage..."
 COVERAGE=$(swift test --enable-code-coverage 2>&1 | grep 'lines covered' | awk '{print $1}')


### PR DESCRIPTION
## Summary
- harden `release.sh` with safety checks
- harden `validate_release.sh` with safety checks

## Testing
- `bash -n Scripts/Release/release.sh`
- `bash -n Scripts/Release/validate_release.sh`
- `swift test --enable-code-coverage` *(fails: package 'healthai2030analytics' is using Swift tools version 6.2.0 but the installed version is 6.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_687831bc70ac832199a6978713bb2e50